### PR TITLE
Calculating query complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,33 @@ type ComplexityEstimatorArgs = {
 type ComplexityEstimator = (options: ComplexityEstimatorArgs) => number | void;
 ```
 
+## Calculate query complexity
+```javascript
+import { calculateComplexity, simpleEstimator } from "graphql-query-complexity/dist/QueryComplexity";
+import { parse } from 'graphql';
+
+// In a resolver the schema can be retrieved from the info argument.
+const schema = undefined; 
+const query = parse(`
+  query {
+    some_value
+    some_list(count: 10) {
+      some_child_value
+    }
+  }
+`);
+
+const complexity = calculateComplexity({
+  estimators: [
+    simpleEstimator({defaultComplexity: 1})
+  ],
+  schema,
+  query
+});
+
+console.log(complexity); // Output: 3
+```
+
 ## Usage with express-graphql
 
 To use the query complexity analysis validation rule with express-graphql, use something like the

--- a/src/__tests__/QueryComplexity-test.ts
+++ b/src/__tests__/QueryComplexity-test.ts
@@ -14,7 +14,7 @@ import {expect} from 'chai';
 
 import schema from './fixtures/schema';
 
-import ComplexityVisitor from '../QueryComplexity';
+import ComplexityVisitor, {calculateComplexity} from '../QueryComplexity';
 import {
   simpleEstimator,
   fieldConfigEstimator,
@@ -22,6 +22,23 @@ import {
 
 describe('QueryComplexity analysis', () => {
   const typeInfo = new TypeInfo(schema);
+
+  it('should calculate complexity', () => {
+    const ast = parse(`
+      query {
+        variableScalar(count: -100)
+      }
+    `);
+
+    const complexity = calculateComplexity({
+      estimators: [
+        simpleEstimator({defaultComplexity: -100})
+      ],
+      schema: schema,
+      query: ast
+    });
+    expect(complexity).to.equal(0);
+  });
 
   it('should not allow negative cost', () => {
     const ast = parse(`

--- a/src/__tests__/QueryComplexity-test.ts
+++ b/src/__tests__/QueryComplexity-test.ts
@@ -26,18 +26,18 @@ describe('QueryComplexity analysis', () => {
   it('should calculate complexity', () => {
     const ast = parse(`
       query {
-        variableScalar(count: -100)
+        variableScalar(count: 10)
       }
     `);
 
     const complexity = calculateComplexity({
       estimators: [
-        simpleEstimator({defaultComplexity: -100})
+        simpleEstimator({defaultComplexity: 1})
       ],
       schema,
       query: ast
     });
-    expect(complexity).to.equal(0);
+    expect(complexity).to.equal(1);
   });
 
   it('should not allow negative cost', () => {

--- a/src/__tests__/QueryComplexity-test.ts
+++ b/src/__tests__/QueryComplexity-test.ts
@@ -34,7 +34,7 @@ describe('QueryComplexity analysis', () => {
       estimators: [
         simpleEstimator({defaultComplexity: -100})
       ],
-      schema: schema,
+      schema,
       query: ast
     });
     expect(complexity).to.equal(0);


### PR DESCRIPTION
This pull request adds a helper function to calculate query complexity independently from query execution, see #16. 

I was unsure if other tests should also use this functionality. Some don't just use the complexity value, but also errors found in ```ValidationContext``` after validating, so that would require some modification.