### PR TITLE
Skip complexity calculation by directiveEstimator when astNode is undefined

### DIFF
--- a/src/__tests__/QueryComplexity-test.ts
+++ b/src/__tests__/QueryComplexity-test.ts
@@ -17,6 +17,7 @@ import schema from './fixtures/schema';
 import ComplexityVisitor, {getComplexity} from '../QueryComplexity';
 import {
   simpleEstimator,
+  directiveEstimator,
   fieldConfigEstimator,
 } from '../index';
 
@@ -320,5 +321,46 @@ describe('QueryComplexity analysis', () => {
       'No complexity could be calculated for field Query.scalar. ' +
       'At least one complexity estimator has to return a complexity score.'
     );
+  });
+
+  it('should return NaN when no astNode available on field when use directiveEstimator', () => {
+    const ast = parse(`
+      query {
+        _service {
+          sdl
+        }
+      }
+    `);
+
+    const complexity = getComplexity({
+      estimators: [
+        directiveEstimator(),
+      ],
+      schema,
+      query: ast
+    });
+    expect(Number.isNaN(complexity)).to.equal(true);
+  });
+  
+  it('should skip complexity calculation by directiveEstimator when no astNode available on field', () => {
+    const ast = parse(`
+      query {
+        _service {
+          sdl
+        }
+      }
+    `);
+
+    const complexity = getComplexity({
+      estimators: [
+        directiveEstimator(),
+        simpleEstimator({
+          defaultComplexity: 1
+        })
+      ],
+      schema,
+      query: ast
+    });
+    expect(complexity).to.equal(2);
   });
 });

--- a/src/__tests__/fixtures/schema.ts
+++ b/src/__tests__/fixtures/schema.ts
@@ -83,6 +83,14 @@ const Union = new GraphQLUnionType({
   resolveType: () => Item
 });
 
+const SDLInterface = new GraphQLInterfaceType({
+  name: 'SDLInterface',
+  fields: {
+    sdl: { type: GraphQLString }
+  },
+  resolveType: () => '"SDL"'
+});
+
 const Query = new GraphQLObjectType({
   name: 'Query',
   fields: () => ({
@@ -126,7 +134,8 @@ const Query = new GraphQLObjectType({
           type: new GraphQLNonNull(GraphQLInt)
         }
       }
-    }
+    },
+    _service: {type: SDLInterface},
   }),
 });
 

--- a/src/estimators/directive/index.ts
+++ b/src/estimators/directive/index.ts
@@ -28,6 +28,11 @@ export default function (options?: {}): ComplexityEstimator {
   });
 
   return (args: ComplexityEstimatorArgs) => {
+    // Ignore if astNode is undefined
+    if (!args.field.astNode) {
+      return;
+    }
+
     const values = getDirectiveValues(directive, args.field.astNode);
 
     // Ignore if no directive set


### PR DESCRIPTION
Currently, I'm using Apollo Server 2 with Federation.

In [QueryComplexity.ts](https://github.com/slicknode/graphql-query-complexity/blob/master/src/QueryComplexity.ts#L211), I found that `field` in `estimatorArgs` could have `undefined` value in `astNode` property.

And if we use `DirectiveEstimator`, `args.field.astNode` in this [line](https://github.com/slicknode/graphql-query-complexity/blob/master/src/estimators/directive/index.ts#L31) could be `undefined` and make `getDirectiveValues` throws error.

So it's better to set default value of `field.astNode` to an empty object `{}`.

These are which I printed from `field`:

```
_entities:
{ description: '',
    type: [_Entity]!,
    args: [ [Object] ],
    resolve: [Function],
    subscribe: undefined,
    deprecationReason: undefined,
    extensions: undefined,
    astNode: undefined,
    name: '_entities',
    isDeprecated: false,
    [Symbol()]: true },
```

```
_service:
{ description: undefined,
    type: _Service!,
    args: [],
    resolve: [Function],
    subscribe: undefined,
    deprecationReason: undefined,
    extensions: undefined,
    astNode: undefined,
    name: '_service',
    isDeprecated: false,
    [Symbol()]: true },
```

**Update**: Skip complexity calculation by `directiveEstimator` when `astNode` is `undefined`