### PR TITLE
Required onError parameter in graphql ValidationContext

### DIFF
--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -91,7 +91,7 @@ export function getComplexity(options: {
 }): number {
   const typeInfo = new TypeInfo(options.schema);
 
-  const context = new ValidationContext(options.schema, options.query, typeInfo);
+  const context = new ValidationContext(options.schema, options.query, typeInfo, () => {});
   const visitor = new QueryComplexity(context, {
     // Maximum complexity does not matter since we're only interested in the calculated complexity.
     maximumComplexity: Infinity,


### PR DESCRIPTION
In the [recent release](https://github.com/graphql/graphql-js/releases/tag/v15.0.0) of graphql-js plugin there has been a breaking change in `ValidationContext` class which now requires a fourth "onError" parameter in its constructor.

See: https://github.com/graphql/graphql-js/pull/2130/files

Right now, if the client sends a query without a required parameter, the graphql server throws an error which is incorrectly handled in the `graphql-query-complexity` plugin so it throws a new error:
```
TypeError: this._onError is not a function
    at ValidationContext.reportError (.../node_modules/graphql/validation/ValidationContext.js:46:10)
    at .../node_modules/graphql-query-complexity/dist/QueryComplexity.js:121:49
    at Array.reduce (<anonymous>)
    at QueryComplexity.nodeComplexity (.../node_modules/graphql-query-complexity/dist/QueryComplexity.js:85:62)
    at QueryComplexity.onOperationDefinitionEnter (.../node_modules/graphql-query-complexity/dist/QueryComplexity.js:56:41)
    at Object.enter (.../node_modules/graphql/utilities/TypeInfo.js:370:25)
    at Object.visit (.../node_modules/graphql/language/visitor.js:243:26)
    at getComplexity (.../node_modules/graphql-query-complexity/dist/QueryComplexity.js:24:15)
 ```

To fix this, we can add an empty error handler (this plugin only calculates complexity, not handling invalid GQL queries so an empty function should be fine)