### PR TITLE
fix: More specific return types.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { QueryComplexityOptions } from './QueryComplexity';
 export * from './estimators';
 export * from './QueryComplexity';
 
-export default function createQueryComplexityValidator(options: QueryComplexityOptions): Function {
+export default function createQueryComplexityValidator(options: QueryComplexityOptions): (context: ValidationContext) => QueryComplexity {
   return (context: ValidationContext): QueryComplexity => {
     return new QueryComplexity(context, options);
   };


### PR DESCRIPTION
Having a generic return type like `Function` is like using `any` it is removing type safety and causes Type Safe environments like NestJS to through errors. It is much better to specify the the return type of this higher order function.
Generally I would let TypeScript infer it without the type def, however since you had it explicitly stated before I simply changed it to be more specific.