### PR TITLE
CI: Test against multiple graphql versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,28 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2
+version: 2.1
+
+workflows:
+  all-tests:
+    jobs:
+      - test-and-build:
+          # Override graphql-version to test against specific versions. Type checking is disabled due missing
+          # definitions for field extensions in older @types/graphql versions
+          matrix:
+            parameters:
+              graphql-version: ["~0.13", "~14.0", "~14.5", "~14.6"]
+      - test-and-build:
+          # Leave graphql-version unspecified to respect the lockfile and also run tsc
+          name: test-and-build-with-typecheck
+
 jobs:
-  build:
+  test-and-build:
+    parameters:
+      graphql-version:
+        type: string
+        default: ""
+
     docker:
       # specify the version you desire here
       - image: circleci/node:latest
@@ -17,16 +36,24 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
+          - v1-dependencies-{{ checksum "package.json" }}-<< parameters.graphql-version >>
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: yarn
+      - when:
+          condition: << parameters.graphql-version >>
+          steps:
+            - run: yarn install --ignore-scripts
+            - run: yarn --ignore-scripts add --dev graphql@<< parameters.graphql-version >>
+      - unless:
+          condition: << parameters.graphql-version >>
+          steps:
+            - run: yarn install --frozen-lockfile
 
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: v1-dependencies-{{ checksum "package.json" }}-<< parameters.graphql-version >>
 
       # run tests!
       - run: yarn test

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf dist/*",
     "build": "tsc",
     "test": "npm run lint && npm run testonly",
-    "testonly": "mocha --check-leaks --exit --full-trace --require ts-node/register 'src/**/__tests__/**/*-test.{ts,tsx}'",
+    "testonly": "mocha --check-leaks --exit --full-trace --require ts-node/register/transpile-only 'src/**/__tests__/**/*-test.{ts,tsx}'",
     "dist": "npm run clean && tsc && npm run build",
     "prepublish": "npm run clean && npm run dist"
   },


### PR DESCRIPTION
Currently tests are run against the latest version of `graphql` matching the semver expression in `devDependencies`.

This PR aims to ensure that as we support new versions of `graphql` we don't introduce regressions for older ones, and we can have confidence in the `peerDependencies` range.

Type checking _is not enforced_ when using the matrix to specify a version of `graphql` to test against, because:
 - It makes the CI config simpler not to have to work out whether `@types/graphql` is necessary and what version it should be at for any given `graphql` version.
 - Older and imperfect type definitions mean that CI would fail on type check even though the built package would work perfectly well - eg old `@types/graphql` definitions did not allow field `extensions` for some time after `graphql` implemented them.

Type checking _is enforced_ in the `test-and-build-with-typecheck` job, which respects `yarn.lock` and runs `tsc`