### PR TITLE
Return max complexity for UnionType / Interfaces

### DIFF
--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -179,14 +179,13 @@ export default class QueryComplexity {
   nodeComplexity(
     node: FieldNode | FragmentDefinitionNode | InlineFragmentNode | OperationDefinitionNode,
     typeDef: GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType,
-    complexity: number = 0
   ): number {
     if (node.selectionSet) {
       let fields:GraphQLFieldMap<any, any> = {};
       if (typeDef instanceof GraphQLObjectType || typeDef instanceof GraphQLInterfaceType) {
         fields = typeDef.getFields();
       }
-      return complexity + node.selectionSet.selections.reduce(
+      return node.selectionSet.selections.reduce(
         (total: number, childNode: FieldNode | FragmentSpreadNode | InlineFragmentNode) => {
           let nodeComplexity = 0;
 
@@ -275,7 +274,6 @@ export default class QueryComplexity {
             case Kind.INLINE_FRAGMENT: {
               let inlineFragmentType = typeDef;
               if (childNode.typeCondition && childNode.typeCondition.name) {
-                // $FlowFixMe: Not sure why flow thinks this can still be NULL
                 inlineFragmentType = assertCompositeType(
                   this.context.getSchema().getType(childNode.typeCondition.name.value)
                 );
@@ -290,9 +288,9 @@ export default class QueryComplexity {
             }
           }
           return Math.max(nodeComplexity, 0) + total;
-        }, complexity);
+        }, 0);
     }
-    return complexity;
+    return 0;
   }
 
   createError(): GraphQLError {

--- a/src/__tests__/QueryComplexity-test.ts
+++ b/src/__tests__/QueryComplexity-test.ts
@@ -482,4 +482,32 @@ describe('QueryComplexity analysis', () => {
     });
     expect(complexity2).to.equal(20);
   });
+
+  it('should calculate max complexity for fragment on union type', () => {
+    const query = parse(`
+      query Primary {
+        union {
+          ...on Item {
+            scalar
+          }
+          ...on SecondItem {
+            scalar
+          }
+          ...on SecondItem {
+            scalar
+          }
+        }
+      }
+    `);
+
+    const complexity = getComplexity({
+      estimators: [
+        fieldExtensionsEstimator(),
+        simpleEstimator({defaultComplexity: 1})
+      ],
+      schema,
+      query,
+    });
+    expect(complexity).to.equal(3);
+  });
 });

--- a/src/__tests__/fixtures/schema.ts
+++ b/src/__tests__/fixtures/schema.ts
@@ -63,6 +63,14 @@ const NameInterface = new GraphQLInterfaceType({
   resolveType: () => Item
 });
 
+const UnionInterface = new GraphQLInterfaceType({
+  name: 'UnionInterface',
+  fields: () => ({
+    union: { type: Union }
+  }),
+  resolveType: () => Item
+});
+
 const SecondItem = new GraphQLObjectType({
   name: 'SecondItem',
   fields: () => ({
@@ -92,7 +100,15 @@ const SDLInterface = new GraphQLInterfaceType({
   fields: {
     sdl: { type: GraphQLString }
   },
-  resolveType: () => '"SDL"'
+  resolveType: () => 'SDL'
+});
+
+const SDL = new GraphQLObjectType({
+  name: 'SDL',
+  fields: {
+    sdl: { type: GraphQLString }
+  },
+  interfaces: () => [SDLInterface],
 });
 
 const Query = new GraphQLObjectType({
@@ -145,6 +161,12 @@ const Query = new GraphQLObjectType({
     },
     _service: {type: SDLInterface},
   }),
+  interfaces: () => [NameInterface, UnionInterface,]
 });
 
-export default new GraphQLSchema({ query: Query });
+export default new GraphQLSchema({
+  query: Query,
+  types: [
+    SDL,
+  ],
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     },
     "lib": [
       "es2015",
+      "es2018",
       "esnext.asynciterable",
       "dom"
     ]


### PR DESCRIPTION
This adds support for union/interface types in fields and returns the maximum complexity for all possible types, instead of adding all field complexities. Fixes #26 