### PR TITLE
fix(directives): field node directives property is optional

### DIFF
--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -201,7 +201,7 @@ export default class QueryComplexity {
           let includeNode = true;
           let skipNode = false;
 
-          childNode.directives.forEach((directive: DirectiveNode) => {
+          childNode.directives?.forEach((directive: DirectiveNode) => {
             const directiveName = directive.name.value;
             switch (directiveName) {
               case 'include': {


### PR DESCRIPTION
Hi, thanks for the module, it's a great help!
I run into an issue where my application faisl when `FieldNode` doesn't have directives. 
As `directives` is an optional property on `FieldNode`, I created this PR to address this issue.

`FieldNode.directives` is an optional property:
https://github.com/graphql/graphql-js/blob/7b3241329e1ff49fb647b043b80568f0cf9e1a7c/src/language/ast.js#L296-L304

Please let me know if you need a change to proceed with it.