### PR TITLE
Catch invalid graphql query

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "lint": "eslint src/**/*.ts",
+    "lint:fix": "eslint --fix src/**/*.ts",
     "clean": "rimraf dist/*",
     "build": "tsc",
     "test": "npm run lint && npm run testonly",

--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -278,24 +278,26 @@ export default class QueryComplexity {
             }
             case Kind.FRAGMENT_SPREAD: {
               const fragment = this.context.getFragment(childNode.name.value);
-              const fragmentType = assertCompositeType(
-                this.context.getSchema().getType(fragment.typeCondition.name.value)
-              );
-              const nodeComplexity = this.nodeComplexity(fragment, fragmentType);
-              if (isAbstractType(fragmentType)) {
-                // Add fragment complexity for all possible types
-                complexities = addComplexities(
-                  nodeComplexity,
-                  complexities,
-                  this.context.getSchema().getPossibleTypes(fragmentType).map(t => t.name),
+              if (fragment) {
+                const fragmentType = assertCompositeType(
+                  this.context.getSchema().getType(fragment.typeCondition.name.value)
                 );
-              } else {
-                // Add complexity for object type
-                complexities = addComplexities(
-                  nodeComplexity,
-                  complexities,
-                  [fragmentType.name],
-                );
+                const nodeComplexity = this.nodeComplexity(fragment, fragmentType);
+                if (isAbstractType(fragmentType)) {
+                  // Add fragment complexity for all possible types
+                  complexities = addComplexities(
+                    nodeComplexity,
+                    complexities,
+                    this.context.getSchema().getPossibleTypes(fragmentType).map(t => t.name),
+                  );
+                } else {
+                  // Add complexity for object type
+                  complexities = addComplexities(
+                    nodeComplexity,
+                    complexities,
+                    [fragmentType.name],
+                  );
+                }
               }
               break;
             }

--- a/src/__tests__/QueryComplexity-test.ts
+++ b/src/__tests__/QueryComplexity-test.ts
@@ -166,6 +166,45 @@ describe('QueryComplexity analysis', () => {
     expect(visitor.complexity).to.equal(0);
   });
 
+  it('should ignore unknown fragments', () => {
+    const ast = parse(`
+      query {
+        ...UnknownFragment
+        variableScalar(count: 100)
+      }
+    `);
+
+    const context = new CompatibleValidationContext(schema, ast, typeInfo);
+    const visitor = new ComplexityVisitor(context, {
+      maximumComplexity: 100,
+      estimators: [
+        simpleEstimator({defaultComplexity: 10})
+      ]
+    });
+
+    visit(ast, visitWithTypeInfo(typeInfo, visitor));
+    expect(visitor.complexity).to.equal(10);
+  });
+
+  it('should ignore unused variables', () => {
+    const ast = parse(`
+      query ($unusedVar: ID!) {
+        variableScalar(count: 100)
+      }
+    `);
+
+    const context = new CompatibleValidationContext(schema, ast, typeInfo);
+    const visitor = new ComplexityVisitor(context, {
+      maximumComplexity: 100,
+      estimators: [
+        simpleEstimator({defaultComplexity: 10})
+      ]
+    });
+
+    visit(ast, visitWithTypeInfo(typeInfo, visitor));
+    expect(visitor.complexity).to.equal(10);
+  });
+
   it('should report error above threshold', () => {
     const ast = parse(`
       query {


### PR DESCRIPTION
This adds handling of invalid GraphQL queries:
- Unknown fragments in query
- Fragments on unknown types
Fixes #35 