### PR TITLE
docs(readme): fix the import

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ To use the query complexity analysis validation rule with express-graphql, use s
 following: 
 
 ```javascript
-import queryComplexity from 'graphql-query-complexity';
+import queryComplexity, { simpleEstimator } from 'graphql-query-complexity';
 import express from 'express';
 import graphqlHTTP from 'express-graphql';
 import schema from './schema';


### PR DESCRIPTION
Add missing `simpleEstimator` for the express-graphql demo.
BTW, thanks for the awesome library!