### PR TITLE
Feature/custom layer operation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Create the rule with a maximum query complexity:
 
 ```javascript
 import queryComplexity, {
-  simpleEstimator
+  simpleEstimator, 
+  LayerTransformation
 } from 'graphql-query-complexity';
 
 const rule = queryComplexity({
@@ -60,7 +61,10 @@ const rule = queryComplexity({
     simpleEstimator({
       defaultComplexity: 1
     })
-  ]
+  ],
+    
+  // Optional operation applied on fields on same level / layer in graph tree
+  layerTransformation?: LayerTransformation;
 });
 ```
 


### PR DESCRIPTION
Hi, thanks for nice library, it is really useful! 

Although it probably wasn't original purpose of this library, we needed in our project to calculate and check asymptotic complexity of queries. 
This can be done by multiplying instead of adding complexities on each level in query tree. 

<br>

So field that has complexity of n can be set estimator like this:
```
complexity: ({ childComplexity }) => childComplexity * n
```
-> So if childComplexity is also n, asymptotic complexity is n^2

<br>

Problem is that there is addition inside of `addComplexities` function
```
complexityMap[type] + complexity
```
-> Fields on same level are added up.

<br>

So to solve this, I added `layerTransformation: LayerTransformation` optional option to `getComplexity` function to customize this behavior. 

<br>

To calculate asymptotic complexity you can just pass your own transformation function:
```
 const complexity = getComplexity({
                    ...
                    layerTransformation: (a, b) => a * b;
                });
```

And to calculate asymptotic complexity on each query:
```
 const complexity = getComplexity({
                    ...
                    layerTransformation: (a, b, type) => {
                        if (type === 'Query') {
                            return a + b;
                        }
                        return a * b;
                    }
                });
```
