### PR TITLE
chore: change prepublish command to prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "npm run lint && npm run testonly",
     "testonly": "mocha --check-leaks --exit --full-trace --require ts-node/register/transpile-only 'src/**/__tests__/**/*-test.{ts,tsx}'",
     "dist": "npm run clean && tsc && npm run build",
-    "prepublish": "npm run clean && npm run dist"
+    "prepare": "npm run clean && npm run dist"
   },
   "directories": {
     "lib": "./dist"


### PR DESCRIPTION
Prepublish command is deprecated in npm.

See https://docs.npmjs.com/cli/v6/using-npm/scripts#life-cycle-scripts

I only changed prepublish command to prepare. Without this change package cannot be installed as dependency directly from git repository. 