### PR TITLE
Export complexity directive

### DIFF
--- a/src/estimators/directive/README.md
+++ b/src/estimators/directive/README.md
@@ -63,3 +63,19 @@ input Filter {
 ```
 
 The multipliers can be combined. Configured multipliers that don't have a value or `NULL` are ignored. 
+
+Code first approach can use the `createComplexityDirective` function to generate directive definition:
+
+```typescript
+import {createComplexityDirective} from 'graphql-query-complexity';
+
+const schema = new GraphQLSchema({
+  directives: [
+    createComplexityDirective({
+      // Optionally change the name of the directive here... Default value is `complexity`
+      name: 'complexity'
+    })
+  ]
+  // ... other config
+});
+```

--- a/src/estimators/directive/__tests__/directiveEstimator-test.ts
+++ b/src/estimators/directive/__tests__/directiveEstimator-test.ts
@@ -10,6 +10,7 @@ import {
   TypeInfo,
   visit,
   visitWithTypeInfo,
+  buildSchema
 } from 'graphql';
 
 import {expect} from 'chai';
@@ -254,11 +255,16 @@ describe('directiveEstimator analysis', () => {
     const codeFirstSchema = new GraphQLSchema({
       directives: [complexityDirective]
     });
-    
-    const printedCodeFirstSchema = printSchema(codeFirstSchema).trim();
-    const printedComplexityDirective = print(schema.getDirective('complexity').astNode).trim();
 
-    expect(printedCodeFirstSchema).to.equal(printedComplexityDirective);
+    // rebuilding code first schema
+    // graphql-js <= 14 prints descriptions in different ways printSchema(schema) vs print(astNode)
+    // and directive from code first schema has no astNode
+    const builtCodeFirstSchema = buildSchema(printSchema(codeFirstSchema));
+
+    const printedSchemaFirstDirective = print(schema.getDirective('complexity').astNode);
+    const printedCodeFirstDirective = print(builtCodeFirstSchema.getDirective('complexity').astNode);
+
+    expect(printedSchemaFirstDirective).to.equal(printedCodeFirstDirective);
   });
 
   it('should create complexity directive with configured name', () => {
@@ -267,9 +273,14 @@ describe('directiveEstimator analysis', () => {
       directives: [complexityDirective]
     });
 
-    const printedCodeFirstSchema = printSchema(codeFirstSchema).trim();
-    const printedComplexityDirective = print(schema.getDirective('cost').astNode).trim();
+    // rebuilding code first schema
+    // graphql-js <= 14 prints descriptions in different ways printSchema(schema) vs print(astNode)
+    // and directive from code first schema has no astNode
+    const builtCodeFirstSchema = buildSchema(printSchema(codeFirstSchema));
 
-    expect(printedCodeFirstSchema).to.equal(printedComplexityDirective);
+    const printedSchemaFirstDirective = print(schema.getDirective('cost').astNode);
+    const printedCodeFirstDirective = print(builtCodeFirstSchema.getDirective('cost').astNode);
+
+    expect(printedSchemaFirstDirective).to.equal(printedCodeFirstDirective);
   });
 });

--- a/src/estimators/directive/__tests__/fixtures/schema.ts
+++ b/src/estimators/directive/__tests__/fixtures/schema.ts
@@ -7,12 +7,16 @@ import {
 } from 'graphql';
 
 export default buildSchema(`
+"""Define a relation between the field and other nodes"""
 directive @cost(
+  """The complexity value for the field"""
   value: Int!,
   multipliers: [String!]
 ) on FIELD_DEFINITION
 
+"""Define a relation between the field and other nodes"""
 directive @complexity(
+  """The complexity value for the field"""
   value: Int!,
   multipliers: [String!]
 ) on FIELD_DEFINITION

--- a/src/estimators/directive/index.ts
+++ b/src/estimators/directive/index.ts
@@ -8,7 +8,7 @@ export type ComplexityDirectiveOptions = {
   name?: string
 }
 
-export function createComplexityDirective(options: ComplexityDirectiveOptions = {}) {
+export function createComplexityDirective(options?: ComplexityDirectiveOptions) {
   const mergedOptions = {
     name: 'complexity',
     ...(options || {})

--- a/src/estimators/directive/index.ts
+++ b/src/estimators/directive/index.ts
@@ -4,12 +4,21 @@ import { GraphQLDirective } from 'graphql/type/directives';
 import { DirectiveLocation } from 'graphql/language/directiveLocation';
 import get from 'lodash.get';
 
-export function complexityDirective(name: string = 'complexity') {
+export type ComplexityDirectiveOptions = {
+  name?: string
+}
+
+export function createComplexityDirective(options: ComplexityDirectiveOptions = {}) {
+  const mergedOptions = {
+    name: 'complexity',
+    ...(options || {})
+  };
+
   return new GraphQLDirective({
-    name,
+    name: mergedOptions.name,
     description: 'Define a relation between the field and other nodes',
     locations: [
-      DirectiveLocation.FIELD,
+      DirectiveLocation.FIELD_DEFINITION,
     ],
     args: {
       value: {
@@ -23,8 +32,8 @@ export function complexityDirective(name: string = 'complexity') {
   });
 }
 
-export default function (options: { name?: string } = {}): ComplexityEstimator {
-  const directive = complexityDirective(options.name);
+export default function (options: ComplexityDirectiveOptions = {}): ComplexityEstimator {
+  const directive = createComplexityDirective(options);
 
   return (args: ComplexityEstimatorArgs) => {
     // Ignore if astNode is undefined

--- a/src/estimators/directive/index.ts
+++ b/src/estimators/directive/index.ts
@@ -4,14 +4,9 @@ import { GraphQLDirective } from 'graphql/type/directives';
 import { DirectiveLocation } from 'graphql/language/directiveLocation';
 import get from 'lodash.get';
 
-export default function (options?: {}): ComplexityEstimator {
-  const mergedOptions = {
-    name: 'complexity',
-    ...(options || {})
-  };
-
-  const directive = new GraphQLDirective({
-    name: mergedOptions.name,
+export function complexityDirective(name: string = 'complexity') {
+  return new GraphQLDirective({
+    name,
     description: 'Define a relation between the field and other nodes',
     locations: [
       DirectiveLocation.FIELD,
@@ -26,6 +21,10 @@ export default function (options?: {}): ComplexityEstimator {
       }
     },
   });
+}
+
+export default function (options: { name?: string } = {}): ComplexityEstimator {
+  const directive = complexityDirective(options.name);
 
   return (args: ComplexityEstimatorArgs) => {
     // Ignore if astNode is undefined

--- a/src/estimators/index.ts
+++ b/src/estimators/index.ts
@@ -1,3 +1,3 @@
 export {default as simpleEstimator} from './simple';
-export {default as directiveEstimator} from './directive';
+export {default as directiveEstimator, complexityDirective} from './directive';
 export {default as fieldExtensionsEstimator} from './fieldExtensions';

--- a/src/estimators/index.ts
+++ b/src/estimators/index.ts
@@ -1,3 +1,3 @@
 export {default as simpleEstimator} from './simple';
-export {default as directiveEstimator, complexityDirective} from './directive';
+export {default as directiveEstimator, ComplexityDirectiveOptions, createComplexityDirective} from './directive';
 export {default as fieldExtensionsEstimator} from './fieldExtensions';


### PR DESCRIPTION
In such a way complexity directive can be reused in code first approach to include directive definition in generated typeDefs:

```
new GraphQLSchema({
  directives: [complexityDirective()]
})
```