### PR TITLE
Add node to ComplexityEstimatorArgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ type ComplexityEstimatorArgs = {
   // The GraphQLField that is being evaluated
   field: GraphQLField<any, any>,
   
+  // The GraphQL node that is being evaluated
+  node: FieldNode,
+  
   // The input arguments of the field
   args: {[key: string]: any},
   

--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -33,6 +33,7 @@ import {
 export type ComplexityEstimatorArgs = {
   type: GraphQLCompositeType,
   field: GraphQLField<any, any>,
+  node: FieldNode,
   args: {[key: string]: any},
   childComplexity: number
 }
@@ -250,6 +251,7 @@ export default class QueryComplexity {
                 childComplexity,
                 args,
                 field,
+                node: childNode,
                 type: typeDef
               };
               const validScore = this.estimators.find(estimator => {


### PR DESCRIPTION
This adds the node value to the estimator args to support more calculation use cases. Fixes #45 