### PR TITLE
Fix linter setup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+/node_modules
+/dist

--- a/.eslintrc
+++ b/.eslintrc
@@ -13,15 +13,8 @@
     "env": {
         "browser": true,
         "es6": true,
-        "node": true
-    },
-
-    "globals": {
-        "describe": true,
-        "expect": true,
-        "it": true,
-        "before": true,
-        "after": true
+        "node": true,
+        "mocha": true
     },
 
     "parserOptions": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "lint": "eslint src/**/*.ts",
-    "lint:fix": "eslint --fix src/**/*.ts",
+    "lint": "eslint --ext .ts .",
+    "lint:fix": "npm run lint -- --fix",
     "clean": "rimraf dist/*",
     "build": "tsc",
     "test": "npm run lint && npm run testonly",

--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -31,11 +31,11 @@ import {
 } from 'graphql';
 
 export type ComplexityEstimatorArgs = {
-  type: GraphQLCompositeType,
-  field: GraphQLField<any, any>,
-  node: FieldNode,
-  args: {[key: string]: any},
-  childComplexity: number
+  type: GraphQLCompositeType;
+  field: GraphQLField<any, any>;
+  node: FieldNode;
+  args: {[key: string]: any};
+  childComplexity: number;
 }
 
 export type ComplexityEstimator = (options: ComplexityEstimatorArgs) => number | void;
@@ -45,27 +45,27 @@ export type Complexity = any;
 
 // Map of complexities for possible types (of Union, Interface types)
 type ComplexityMap = {
-  [typeName: string]: number,
+  [typeName: string]: number;
 }
 
 export interface QueryComplexityOptions {
   // The maximum allowed query complexity, queries above this threshold will be rejected
-  maximumComplexity: number,
+  maximumComplexity: number;
 
   // The query variables. This is needed because the variables are not available
   // in the visitor of the graphql-js library
-  variables?: Object,
+  variables?: Record<string, any>;
 
   // specify operation name only when pass multi-operation documents
-  operationName?: string,
+  operationName?: string;
 
   // Optional callback function to retrieve the determined query complexity
   // Will be invoked whether the query is rejected or not
   // This can be used for logging or to implement rate limiting
-  onComplete?: (complexity: number) => void,
+  onComplete?: (complexity: number) => void;
 
   // Optional function to create a custom error
-  createError?: (max: number, actual: number) => GraphQLError,
+  createError?: (max: number, actual: number) => GraphQLError;
 
   // An array of complexity estimators to use for estimating the complexity
   estimators: Array<ComplexityEstimator>;
@@ -79,11 +79,11 @@ function queryComplexityMessage(max: number, actual: number): string {
 }
 
 export function getComplexity(options: {
-  estimators: ComplexityEstimator[],
-  schema: GraphQLSchema,
-  query: DocumentNode,
-  variables?: Object,
-  operationName?: string
+  estimators: ComplexityEstimator[];
+  schema: GraphQLSchema;
+  query: DocumentNode;
+  variables?: Record<string, any>;
+  operationName?: string;
 }): number {
   const typeInfo = new TypeInfo(options.schema);
 
@@ -104,7 +104,7 @@ export default class QueryComplexity {
   context: ValidationContext;
   complexity: number;
   options: QueryComplexityOptions;
-  OperationDefinition: Object;
+  OperationDefinition: Record<string, any>;
   estimators: Array<ComplexityEstimator>;
   includeDirectiveDef: GraphQLDirective;
   skipDirectiveDef: GraphQLDirective;
@@ -123,7 +123,7 @@ export default class QueryComplexity {
 
     this.includeDirectiveDef = this.context.getSchema().getDirective('include');
     this.skipDirectiveDef = this.context.getSchema().getDirective('skip');
-    this.estimators = options.estimators
+    this.estimators = options.estimators;
 
     this.OperationDefinition = {
       enter: this.onOperationDefinitionEnter,
@@ -181,7 +181,7 @@ export default class QueryComplexity {
     typeDef: GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType,
   ): number {
     if (node.selectionSet) {
-      let fields:GraphQLFieldMap<any, any> = {};
+      let fields: GraphQLFieldMap<any, any> = {};
       if (typeDef instanceof GraphQLObjectType || typeDef instanceof GraphQLInterfaceType) {
         fields = typeDef.getFields();
       }
@@ -191,7 +191,7 @@ export default class QueryComplexity {
       if (isAbstractType(typeDef)) {
         possibleTypeNames = this.context.getSchema().getPossibleTypes(typeDef).map(t => t.name);
       } else {
-        possibleTypeNames = [typeDef.name];
+        possibleTypeNames = [ typeDef.name ];
       }
 
       // Collect complexities for all possible types individually
@@ -302,7 +302,7 @@ export default class QueryComplexity {
                 complexities = addComplexities(
                   nodeComplexity,
                   complexities,
-                  [fragmentType.name],
+                  [ fragmentType.name ],
                 );
               }
               break;
@@ -329,7 +329,7 @@ export default class QueryComplexity {
                 complexities = addComplexities(
                   nodeComplexity,
                   complexities,
-                  [inlineFragmentType.name],
+                  [ inlineFragmentType.name ],
                 );
               }
               break;

--- a/src/__tests__/.eslintrc.js
+++ b/src/__tests__/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    '@typescript-eslint/explicit-function-return-type': "off"
+  }
+}

--- a/src/__tests__/fixtures/CompatibleValidationContext.ts
+++ b/src/__tests__/fixtures/CompatibleValidationContext.ts
@@ -1,6 +1,6 @@
-import { GraphQLError, TypeInfo, ValidationContext } from "graphql";
-import { GraphQLSchema } from "graphql/type/schema";
-import { DocumentNode } from "graphql/language/ast";
+import { GraphQLError, TypeInfo, ValidationContext } from 'graphql';
+import { GraphQLSchema } from 'graphql/type/schema';
+import { DocumentNode } from 'graphql/language/ast';
 
 /**
  * This class is used to test that validation errors are raised correctly
@@ -18,11 +18,11 @@ export class CompatibleValidationContext extends ValidationContext {
     private errors: GraphQLError[] = []
 
     constructor(schema: GraphQLSchema, ast: DocumentNode, typeInfo: TypeInfo) {
-        super(schema, ast, typeInfo, err => this.errors.push(err));
+      super(schema, ast, typeInfo, err => this.errors.push(err));
     }
 
     getErrors(): ReadonlyArray<GraphQLError> {
-        // @ts-ignore
-        return super.getErrors ? super.getErrors() : this.errors
+      // @ts-ignore
+      return super.getErrors ? super.getErrors() : this.errors;
     }
 }

--- a/src/__tests__/fixtures/CompatibleValidationContext.ts
+++ b/src/__tests__/fixtures/CompatibleValidationContext.ts
@@ -22,6 +22,7 @@ export class CompatibleValidationContext extends ValidationContext {
     }
 
     getErrors(): ReadonlyArray<GraphQLError> {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
       // @ts-ignore
       return super.getErrors ? super.getErrors() : this.errors;
     }

--- a/src/__tests__/fixtures/schema.ts
+++ b/src/__tests__/fixtures/schema.ts
@@ -108,7 +108,7 @@ const SDL = new GraphQLObjectType({
   fields: {
     sdl: { type: GraphQLString }
   },
-  interfaces: () => [SDLInterface],
+  interfaces: () => [ SDLInterface ],
 });
 
 const Query = new GraphQLObjectType({
@@ -161,7 +161,7 @@ const Query = new GraphQLObjectType({
     },
     _service: {type: SDLInterface},
   }),
-  interfaces: () => [NameInterface, UnionInterface,]
+  interfaces: () => [ NameInterface, UnionInterface, ]
 });
 
 export default new GraphQLSchema({

--- a/src/__tests__/fixtures/schema.ts
+++ b/src/__tests__/fixtures/schema.ts
@@ -63,14 +63,6 @@ const NameInterface = new GraphQLInterfaceType({
   resolveType: () => Item
 });
 
-const UnionInterface = new GraphQLInterfaceType({
-  name: 'UnionInterface',
-  fields: () => ({
-    union: { type: Union }
-  }),
-  resolveType: () => Item
-});
-
 const SecondItem = new GraphQLObjectType({
   name: 'SecondItem',
   fields: () => ({
@@ -92,6 +84,14 @@ const EnumType = new GraphQLEnumType({
 const Union = new GraphQLUnionType({
   name: 'Union',
   types: [ Item, SecondItem ],
+  resolveType: () => Item
+});
+
+const UnionInterface = new GraphQLInterfaceType({
+  name: 'UnionInterface',
+  fields: () => ({
+    union: { type: Union }
+  }),
   resolveType: () => Item
 });
 

--- a/src/estimators/directive/__tests__/directiveEstimator-test.ts
+++ b/src/estimators/directive/__tests__/directiveEstimator-test.ts
@@ -253,7 +253,7 @@ describe('directiveEstimator analysis', () => {
   it('should create complexity directive that can be used to generate directive definition', () => {
     const complexityDirective = createComplexityDirective();
     const codeFirstSchema = new GraphQLSchema({
-      directives: [complexityDirective]
+      directives: [ complexityDirective ]
     });
 
     // rebuilding code first schema
@@ -270,7 +270,7 @@ describe('directiveEstimator analysis', () => {
   it('should create complexity directive with configured name', () => {
     const complexityDirective = createComplexityDirective({name: 'cost'});
     const codeFirstSchema = new GraphQLSchema({
-      directives: [complexityDirective]
+      directives: [ complexityDirective ]
     });
 
     // rebuilding code first schema

--- a/src/estimators/directive/index.ts
+++ b/src/estimators/directive/index.ts
@@ -5,7 +5,7 @@ import { DirectiveLocation } from 'graphql/language/directiveLocation';
 import get from 'lodash.get';
 
 export type ComplexityDirectiveOptions = {
-  name?: string
+  name?: string;
 }
 
 export function createComplexityDirective(options?: ComplexityDirectiveOptions) {

--- a/src/estimators/directive/index.ts
+++ b/src/estimators/directive/index.ts
@@ -8,7 +8,7 @@ export type ComplexityDirectiveOptions = {
   name?: string;
 }
 
-export function createComplexityDirective(options?: ComplexityDirectiveOptions) {
+export function createComplexityDirective(options?: ComplexityDirectiveOptions): GraphQLDirective {
   const mergedOptions = {
     name: 'complexity',
     ...(options || {})
@@ -35,7 +35,7 @@ export function createComplexityDirective(options?: ComplexityDirectiveOptions) 
 export default function (options: ComplexityDirectiveOptions = {}): ComplexityEstimator {
   const directive = createComplexityDirective(options);
 
-  return (args: ComplexityEstimatorArgs) => {
+  return (args: ComplexityEstimatorArgs): number | void => {
     // Ignore if astNode is undefined
     if (!args.field.astNode) {
       return;

--- a/src/estimators/fieldExtensions/__tests__/fixtures/schema.ts
+++ b/src/estimators/fieldExtensions/__tests__/fixtures/schema.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
 /**
  * Created by Ivo Meißner on 28.07.17.
  */

--- a/src/estimators/fieldExtensions/index.ts
+++ b/src/estimators/fieldExtensions/index.ts
@@ -1,7 +1,7 @@
 import {ComplexityEstimator, ComplexityEstimatorArgs} from '../../QueryComplexity';
 
 export default function (): ComplexityEstimator {
-  return (args: ComplexityEstimatorArgs) => {
+  return (args: ComplexityEstimatorArgs): number | void => {
     if (args.field.extensions) {
       // Calculate complexity score
       if (typeof args.field.extensions.complexity === 'number') {

--- a/src/estimators/simple/__tests__/.eslintrc.js
+++ b/src/estimators/simple/__tests__/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    '@typescript-eslint/explicit-function-return-type': "off"
+  }
+}

--- a/src/estimators/simple/index.ts
+++ b/src/estimators/simple/index.ts
@@ -2,7 +2,7 @@ import {ComplexityEstimator, ComplexityEstimatorArgs} from '../../QueryComplexit
 
 export default function (options?: {defaultComplexity?: number}): ComplexityEstimator {
   const defaultComplexity = options && typeof options.defaultComplexity === 'number' ? options.defaultComplexity : 1;
-  return (args: ComplexityEstimatorArgs) => {
+  return (args: ComplexityEstimatorArgs): number | void => {
     return defaultComplexity + args.childComplexity;
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,9 @@ import { QueryComplexityOptions } from './QueryComplexity';
 export * from './estimators';
 export * from './QueryComplexity';
 
-export default function createQueryComplexityValidator(options: QueryComplexityOptions): (context: ValidationContext) => QueryComplexity {
+export default function createQueryComplexityValidator(
+  options: QueryComplexityOptions
+): (context: ValidationContext) => QueryComplexity {
   return (context: ValidationContext): QueryComplexity => {
     return new QueryComplexity(context, options);
   };


### PR DESCRIPTION
Hej folks,

while I wanted to work on this library for a proposed fix, I realized that the current linter setup was not actually linting TypeScript files. (I've screwed up this globbing vs. `--ext` a couple times myself 😅 )

To make it easier to track the changes I've split up the work into multiple easy-to-review commits, and would recommend to not review `chore: ESLint autofixes` (0a5d8bd) as it exclusively enforces linting rules you've set up previously and they are tested by the ESLint autofix implementation.

The two biggest changes are replacing a single `forEach` with a `for-of` loop to fix `no-unused-expressions` and introducing a new `innerComplexities` variables to fix `no-param-reassign`.