### PR TITLE
Add fallback for missing child complexity in simple estimator

### DIFF
--- a/src/estimators/simple/__tests__/fixtures/schema.ts
+++ b/src/estimators/simple/__tests__/fixtures/schema.ts
@@ -12,6 +12,7 @@ import {
   GraphQLEnumType,
   GraphQLUnionType,
   GraphQLInterfaceType,
+  GraphQLScalarType,
 } from 'graphql';
 
 const Item: GraphQLObjectType = new GraphQLObjectType({
@@ -70,6 +71,34 @@ const Union = new GraphQLUnionType({
   resolveType: () => Item,
 });
 
+const ErrorThrower = new GraphQLObjectType({
+  name: 'ErrorType',
+  fields: {
+    errorScalar: {
+      type: new GraphQLObjectType({
+        name: 'ErrorScalar',
+        fields: { irrelevant: { type: GraphQLString } },
+      }),
+      args: {
+        throws: {
+          type: new GraphQLScalarType({
+            name: 'Throws',
+            parseValue() {
+              throw new Error('Scalar parse error');
+            },
+            parseLiteral() {
+              throw new Error('Scalar parse error');
+            },
+            serialize() {
+              return '';
+            },
+          }),
+        },
+      },
+    },
+  },
+});
+
 const Query = new GraphQLObjectType({
   name: 'Query',
   fields: () => ({
@@ -110,6 +139,9 @@ const Query = new GraphQLObjectType({
           type: new GraphQLNonNull(GraphQLInt),
         },
       },
+    },
+    errorThrower: {
+      type: ErrorThrower,
     },
   }),
 });

--- a/src/estimators/simple/__tests__/simpleEstimator-test.ts
+++ b/src/estimators/simple/__tests__/simpleEstimator-test.ts
@@ -210,4 +210,25 @@ describe('simple estimator', () => {
     visit(ast, visitWithTypeInfo(typeInfo, visitor));
     expect(visitor.complexity).to.equal(1);
   });
+
+  it('should fall back on default complexity when child complexity cannot be computed', () => {
+    const ast = parse(`
+      query {
+        errorThrower {
+          errorScalar(throws: "an error") {
+            irrelevant
+          }
+        }
+      }
+    `);
+
+    const context = new CompatibleValidationContext(schema, ast, typeInfo);
+    const visitor = new ComplexityVisitor(context, {
+      maximumComplexity: 100,
+      estimators: [simpleEstimator({ defaultComplexity: 1 })],
+    });
+
+    visit(ast, visitWithTypeInfo(typeInfo, visitor));
+    expect(visitor.complexity).to.equal(1);
+  });
 });

--- a/src/estimators/simple/index.ts
+++ b/src/estimators/simple/index.ts
@@ -11,6 +11,9 @@ export default function (options?: {
       ? options.defaultComplexity
       : 1;
   return (args: ComplexityEstimatorArgs): number | void => {
-    return defaultComplexity + args.childComplexity;
+    const { childComplexity } = args;
+    return (
+      defaultComplexity + (Number.isNaN(childComplexity) ? 0 : childComplexity)
+    );
   };
 }


### PR DESCRIPTION
Hello,

In the docs it states that the simple estimator "can be used as the last estimator in the chain for a default value". Unfortunately, that's not always the case - if child node complexity computation fails, then `args.childComplexity` will be `NaN`, resulting in `NaN` value for the entire complexity estimation and an error being passed to the context here: https://github.com/slicknode/graphql-query-complexity/blob/a940f947dde7261e27d950bbba4939982eb4c4e8/src/QueryComplexity.ts#L335-L342

This PR fixes that by assuming `NaN` value of child complexity calculation to be equal to 0 and falling back to the default complexity value.