### PR TITLE
Report variable coercion errors

### DIFF
--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -180,7 +180,7 @@ export default class QueryComplexity {
       operation.variableDefinitions ? [...operation.variableDefinitions] : [],
       this.options.variables ?? {}
     );
-    if (errors) {
+    if (errors && errors.length) {
       // We have input validation errors, report errors and abort
       errors.forEach((error) => this.context.reportError(error));
       return;

--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -174,12 +174,18 @@ export default class QueryComplexity {
 
     // Get variable values from variables that are passed from options, merged
     // with default values defined in the operation
-    this.variableValues = getVariableValues(
+    const { coerced, errors } = getVariableValues(
       this.context.getSchema(),
       // We have to create a new array here because input argument is not readonly in graphql ~14.6.0
       operation.variableDefinitions ? [...operation.variableDefinitions] : [],
       this.options.variables ?? {}
-    ).coerced;
+    );
+    if (errors) {
+      // We have input validation errors, report errors and abort
+      errors.forEach((error) => this.context.reportError(error));
+      return;
+    }
+    this.variableValues = coerced;
 
     switch (operation.operation) {
       case 'query':

--- a/src/__tests__/fixtures/schema.ts
+++ b/src/__tests__/fixtures/schema.ts
@@ -164,6 +164,14 @@ const Query = new GraphQLObjectType({
         },
       },
     },
+    enumInputArg: {
+      type: GraphQLString,
+      args: {
+        enum: {
+          type: EnumType,
+        },
+      },
+    },
     _service: { type: SDLInterface },
   }),
   interfaces: () => [NameInterface, UnionInterface],


### PR DESCRIPTION
Currently, errors that occur during variable coercion are swallowed, which can lead to misleading error messages. With this change, variable coercion errors that are generated by graphql-js will be reported to the validation context and complexity estimation is aborted. 