### PR TITLE
Bump version to v0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-query-complexity",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Validation rule for GraphQL query complexity analysis",
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",


### PR DESCRIPTION
Bump version to v0.12.0 in order to get https://github.com/slicknode/graphql-query-complexity/pull/78 and https://github.com/slicknode/graphql-query-complexity/pull/77 