### PR TITLE
Bug with `subscription` documents

### DIFF
--- a/src/__tests__/QueryComplexity-test.ts
+++ b/src/__tests__/QueryComplexity-test.ts
@@ -891,4 +891,25 @@ describe('QueryComplexity analysis', () => {
     expect(errors).to.have.length(1);
     expect(errors[0].message).to.contain('INVALIDVALUE');
   });
+
+  it("won't fail on subscription document", () => {
+    const ast = parse(`
+      subscription {
+        foo
+      }
+    `);
+
+    const errors = validate(schema, ast, [
+      createComplexityRule({
+        maximumComplexity: 1000,
+        estimators: [
+          simpleEstimator({
+            defaultComplexity: 1,
+          }),
+        ],
+      }),
+    ]);
+
+    expect(errors).to.have.length(0);
+  });
 });


### PR DESCRIPTION
A `subscription` query results in an error `TypeError: Cannot read properties of undefined (reading 'name')`, originating here: https://github.com/slicknode/graphql-query-complexity/blob/master/src/QueryComplexity.ts#L260.

I am not sure if this is only failing because the server isn't configured handle subscriptions.

This bug is preventing GraphQL from being able to reply with "Schema is not configured to execute subscription operation.". 

This PR adds a test case demonstrating the issue. I haven't time to look into it any further.