### PR TITLE
Default non-defined graphql operations to have 0 complexity

### DIFF
--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -238,9 +238,13 @@ export default class QueryComplexity {
       | FragmentDefinitionNode
       | InlineFragmentNode
       | OperationDefinitionNode,
-    typeDef: GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType
+    typeDef:
+      | GraphQLObjectType
+      | GraphQLInterfaceType
+      | GraphQLUnionType
+      | undefined
   ): number {
-    if (node.selectionSet) {
+    if (node.selectionSet && typeDef) {
       let fields: GraphQLFieldMap<any, any> = {};
       if (
         typeDef instanceof GraphQLObjectType ||

--- a/src/__tests__/QueryComplexity-test.ts
+++ b/src/__tests__/QueryComplexity-test.ts
@@ -891,4 +891,25 @@ describe('QueryComplexity analysis', () => {
     expect(errors).to.have.length(1);
     expect(errors[0].message).to.contain('INVALIDVALUE');
   });
+
+  it('falls back to 0 complexity for GraphQL operations not supported by the schema', () => {
+    const ast = parse(`
+      subscription {
+        foo
+      }
+    `);
+
+    const errors = validate(schema, ast, [
+      createComplexityRule({
+        maximumComplexity: 1000,
+        estimators: [
+          simpleEstimator({
+            defaultComplexity: 1,
+          }),
+        ],
+      }),
+    ]);
+
+    expect(errors).to.have.length(0);
+  });
 });


### PR DESCRIPTION
This fixes the `TypeError: Cannot read properties of undefined (reading 'name')` reported by #84 and #85.

Defaulting to 0 complexity seems reasonable as we cannot reason about fields for which we do not have a type definition.