### PR TITLE
Include meta fields (__typename, __type, __schema) against total field complexity

### DIFF
--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -35,6 +35,9 @@ import {
   Kind,
   getNamedType,
   GraphQLError,
+  SchemaMetaFieldDef,
+  TypeMetaFieldDef,
+  TypeNameMetaFieldDef,
 } from 'graphql';
 
 export type ComplexityEstimatorArgs = {
@@ -307,7 +310,23 @@ export default class QueryComplexity {
 
             switch (childNode.kind) {
               case Kind.FIELD: {
-                const field = fields[childNode.name.value];
+                let field = null
+
+                switch (childNode.name.value) {
+                  case SchemaMetaFieldDef.name:
+                    field = SchemaMetaFieldDef
+                    break;
+                  case TypeMetaFieldDef.name:
+                    field = TypeMetaFieldDef
+                    break;
+                  case TypeNameMetaFieldDef.name:
+                    field = TypeNameMetaFieldDef
+                    break;
+                  default:
+                    field = fields[childNode.name.value];
+                    break;
+                }
+                
                 // Invalid field, should be caught by other validation rules
                 if (!field) {
                   break;

--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -310,23 +310,23 @@ export default class QueryComplexity {
 
             switch (childNode.kind) {
               case Kind.FIELD: {
-                let field = null
+                let field = null;
 
                 switch (childNode.name.value) {
                   case SchemaMetaFieldDef.name:
-                    field = SchemaMetaFieldDef
+                    field = SchemaMetaFieldDef;
                     break;
                   case TypeMetaFieldDef.name:
-                    field = TypeMetaFieldDef
+                    field = TypeMetaFieldDef;
                     break;
                   case TypeNameMetaFieldDef.name:
-                    field = TypeNameMetaFieldDef
+                    field = TypeNameMetaFieldDef;
                     break;
                   default:
                     field = fields[childNode.name.value];
                     break;
                 }
-                
+
                 // Invalid field, should be caught by other validation rules
                 if (!field) {
                   break;


### PR DESCRIPTION
### What

Update `QueryComplexity.ts` to count meta fields against total complexity. The current implementation only considers fields included in the schema, which omits: `__typename`, `__type` and `__schema`.

### Why

Denial of service attacks are possible by creating many aliases of meta fields:

```graphql
query LargeQuery {
  __typename
  alias1: __typename
  alias2: __typename
  ...
  alias1000: __typename
}
```

### Considerations

If counting each field as `1` cost, common introspection queries will have a cost around `180`. Consumers of the library may need to increase the maximum. 
