### PR TITLE
fix(ESM package): QueryComplexity import CJS module from GraphQL

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,3 @@
+{
+  "node-option": ["experimental-specifier-resolution=node"]
+}

--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -8,7 +8,7 @@ import {
   getArgumentValues,
   getDirectiveValues,
   getVariableValues,
-} from 'graphql/execution/values.js';
+} from 'graphql/execution/values';
 
 import {
   ValidationContext,


### PR DESCRIPTION
fix #75

The conflict on the bi-module support of QueryComplexity and graphql has caused the issue. For now if user use ESM, it will load ESM build of query complexity package. But this line of code will load commonjs module of graphql instead of ESM as expected. And it cause the issue that's been mentioned in #75.

The approach here is to allow user's compiler/transpiler decide it should load commonjs or ESM when it reach this line of code: https://github.com/slicknode/graphql-query-complexity/blob/master/src/QueryComplexity.ts#L11-L12.

This can be replaced by import specified extensions once both QueryComplexity and graphql are fully ESM.

