### PR TITLE
Include meta fields (__typename, __type, __schema) against total field complexity [2]

### DIFF
--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -35,6 +35,9 @@ import {
   Kind,
   getNamedType,
   GraphQLError,
+  SchemaMetaFieldDef,
+  TypeMetaFieldDef,
+  TypeNameMetaFieldDef,
 } from 'graphql';
 
 export type ComplexityEstimatorArgs = {
@@ -307,7 +310,23 @@ export default class QueryComplexity {
 
             switch (childNode.kind) {
               case Kind.FIELD: {
-                const field = fields[childNode.name.value];
+                let field = null;
+
+                switch (childNode.name.value) {
+                  case SchemaMetaFieldDef.name:
+                    field = SchemaMetaFieldDef;
+                    break;
+                  case TypeMetaFieldDef.name:
+                    field = TypeMetaFieldDef;
+                    break;
+                  case TypeNameMetaFieldDef.name:
+                    field = TypeNameMetaFieldDef;
+                    break;
+                  default:
+                    field = fields[childNode.name.value];
+                    break;
+                }
+
                 // Invalid field, should be caught by other validation rules
                 if (!field) {
                   break;

--- a/src/__tests__/QueryComplexity-test.ts
+++ b/src/__tests__/QueryComplexity-test.ts
@@ -611,6 +611,33 @@ describe('QueryComplexity analysis', () => {
     expect(complexity2).to.equal(20);
   });
 
+  it('should calculate complexity for meta fields', () => {
+    const query = parse(`
+      query Primary {
+        __typename
+        __type(name: "Primary") {
+          name
+        }
+        __schema {
+          types {
+            name
+          }
+        }
+      }
+    `);
+
+    const complexity = getComplexity({
+      estimators: [
+        fieldExtensionsEstimator(),
+        simpleEstimator({ defaultComplexity: 1 }),
+      ],
+      schema,
+      query,
+    });
+
+    expect(complexity).to.equal(6);
+  });
+
   it('should calculate max complexity for fragment on union type', () => {
     const query = parse(`
       query Primary {


### PR DESCRIPTION
sequel for https://github.com/slicknode/graphql-query-complexity/pull/90 covered with test
original PR is been inactive for half a year, I decided to open a new one

Original description: 
### What
Update `QueryComplexity.ts` to count meta fields against total complexity. The current implementation only considers fields included in the schema, which omits: `__typename`, `__type` and `__schema`.

### Why
Denial of service attacks are possible by creating many aliases of meta fields:

```gql
query LargeQuery {
  __typename
  alias1: __typename
  alias2: __typename
  ...
  alias1000: __typename
}
```
edit: 
simple 300kb with 35k `__typename` fields query is able to load server for almost half-a-minute. It can be used for DoS attacks.

### Considerations
If counting each field as `1` cost, common introspection queries will have a cost around `180`. Consumers of the library may need to increase the maximum.

Probably, to keep compatibility, we can make some optional parameter to include these fields in total complexity, but I think it's unnecessary

