### PR TITLE
Add maxQueryNodes limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import {
 
 const rule = createComplexityRule({
   // The maximum allowed query complexity, queries above this threshold will be rejected
-  maximumComplexity: 1000,
+  maximumComplexity: 1_000,
 
   // The query variables. This is needed because the variables are not available
   // in the visitor of the graphql-js library
@@ -40,8 +40,15 @@ const rule = createComplexityRule({
   // The context object for the request (optional)
   context: {}
 
-  // specify operation name only when pass multi-operation documents
+  // Specify operation name when evaluating multi-operation documents
   operationName?: string,
+
+  // The maximum number of query nodes to evaluate (fields, fragments, composite types).
+  // If a query contains more than the specified number of nodes, the complexity rule will
+  // throw an error, regardless of the complexity of the query.
+  //
+  // Default: 10_000
+  maxQueryNodes?: 10_000,
 
   // Optional callback function to retrieve the determined query complexity
   // Will be invoked whether the query is rejected or not


### PR DESCRIPTION
This PR adds a new option to limit the maximum number of query nodes that are allowed in a query. This is a safety mechanism to prevent overly complex queries from being evaluated, which can lead to resource exhaustion in certain edge cases. 

By default, this library sets a default of 10_000 query nodes, which should be plenty for the overwhelming majority of cases. 