### PR TITLE
dep(lodash.get): remove obsolete dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
   "directories": {
     "lib": "./dist"
   },
-  "dependencies": {
-    "lodash.get": "^4.4.2"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "graphql": "^15.0.0 || ^16.0.0"
   },

--- a/src/estimators/directive/index.ts
+++ b/src/estimators/directive/index.ts
@@ -11,7 +11,6 @@ import {
   GraphQLDirective,
   DirectiveLocation,
 } from 'graphql';
-import get from 'lodash.get';
 
 export type ComplexityDirectiveOptions = {
   name?: string;
@@ -64,7 +63,7 @@ export default function (
     if (values.multipliers && Array.isArray(values.multipliers)) {
       totalMultiplier = values.multipliers.reduce(
         (aggregated: number, multiplier: string) => {
-          const multiplierValue = get(args.args, multiplier);
+          const multiplierValue = args.args?.[multiplier];
 
           if (typeof multiplierValue === 'number') {
             return aggregated * multiplierValue;

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,11 +806,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
-
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"


### PR DESCRIPTION
`lodash.get` is deprecated as it is no-longer necessary; its functionality is available natively via [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) (potentially coupled with [nullish coalescing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing)): https://www.npmjs.com/package/lodash.get

> Author message:
> This package is deprecated. Use the optional chaining (`?.`) operator instead.