### PR TITLE
Add GraphQL v17 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         node-version: [20, 22, 24, 26]
-        graphql-version: ['~15.0', '~16.0']
+        graphql-version: ['~15.0', '~16.0', '~17.0']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         node-version: [20, 22, 24, 26]
-        graphql-version: ['~15.0', '~16.0', '~17.0']
+        graphql-version: ['~16.6', '~16', '~17.0']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 24, 26]
+        node-version: [22, 24, 26]
         graphql-version: ['~16.6', '~16', '~17.0']
     steps:
       - name: Checkout repository
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 24, 26]
+        node-version: [22, 24, 26]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/fix-hybrid-module.sh
+++ b/fix-hybrid-module.sh
@@ -7,20 +7,6 @@ cat >dist/cjs/package.json <<!EOF
 }
 !EOF
 
-# Define the file paths
-cjs_file_path="dist/cjs/QueryComplexity.js"
-esm_file_path="dist/esm/QueryComplexity.js"
-find_path="dist/esm"
-
-# Detect the operating system and use the appropriate sed command
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  # macOS (BSD sed)
-  sed -i '' 's/require("graphql\/execution\/values")/require("graphql\/execution\/values.js")/' "$cjs_file_path"
-else
-  # Linux (GNU sed)
-  sed -i 's/require("graphql\/execution\/values")/require("graphql\/execution\/values.js")/' "$cjs_file_path"
-fi
-
 # Create package.json for ES modules
 cat >dist/esm/package.json <<!EOF
 {
@@ -28,13 +14,9 @@ cat >dist/esm/package.json <<!EOF
 }
 !EOF
 
-# Detect the operating system and use the appropriate sed command
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  # macOS (BSD sed)
-  sed -i '' 's/from '\''graphql\/execution\/values'\'';/from '\''graphql\/execution\/values.mjs'\'';/' "$esm_file_path"
-  find "$find_path" -type f -name "*.js" -exec sed -i '' 's/from '\''graphql'\'';/from '\''graphql\/index.mjs'\'';/' {} +
-else
-  # Linux (GNU sed)
-  sed -i 's/from '\''graphql\/execution\/values'\'';/from '\''graphql\/execution\/values.mjs'\'';/' "$esm_file_path"
-  find "$find_path" -type f -name "*.js" -exec sed -i 's/from '\''graphql'\'';/from '\''graphql\/index.mjs'\'';/' {} +
-fi
+# No import specifiers need rewriting: every graphql import resolves through
+# the bare "graphql" package root. Using a single specifier for both builds
+# guarantees a single graphql instance per realm in every environment
+# (bundler, native ESM, CommonJS) across all supported graphql versions.
+# The deep "graphql/execution/values" import is no longer used because
+# getVariableValues/getArgumentValues are root exports since graphql 16.6.

--- a/fix-hybrid-module.test.cjs.sh
+++ b/fix-hybrid-module.test.cjs.sh
@@ -3,13 +3,3 @@ cat >dist/test/cjs/package.json <<!EOF
     "type": "commonjs"
 }
 !EOF
-
-file_path="dist/test/cjs/QueryComplexity.js"
-
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  # macOS (BSD sed)
-  sed -i '' 's/require("graphql\/execution\/values")/require("graphql\/execution\/values.js")/' "$file_path"
-else
-  # Linux (GNU sed)
-  sed -i 's/require("graphql\/execution\/values")/require("graphql\/execution\/values.js")/' "$file_path"
-fi

--- a/fix-hybrid-module.test.esm.sh
+++ b/fix-hybrid-module.test.esm.sh
@@ -3,6 +3,3 @@ cat >dist/test/esm/package.json <<!EOF
     "type": "module"
 }
 !EOF
-
-# No import specifiers need rewriting: every graphql import resolves through
-# the bare "graphql" package root (see fix-hybrid-module.sh for details).

--- a/fix-hybrid-module.test.esm.sh
+++ b/fix-hybrid-module.test.esm.sh
@@ -4,16 +4,5 @@ cat >dist/test/esm/package.json <<!EOF
 }
 !EOF
 
-file_path="dist/test/esm/QueryComplexity.js"
-find_path="dist/test/esm"
-
-# Detect the operating system and use the appropriate sed command
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  # macOS (BSD sed)
-  sed -i '' 's/from '\''graphql\/execution\/values'\'';/from '\''graphql\/execution\/values.mjs'\'';/' "$file_path"
-  find "$find_path" -type f -name "*.js" -exec sed -i '' 's/from '\''graphql'\'';/from '\''graphql\/index.mjs'\'';/' {} +
-else
-  # Linux (GNU sed)
-  sed -i 's/from '\''graphql\/execution\/values'\'';/from '\''graphql\/execution\/values.mjs'\'';/' "$file_path"
-  find "$find_path" -type f -name "*.js" -exec sed -i 's/from '\''graphql'\'';/from '\''graphql\/index.mjs'\'';/' {} +
-fi
+# No import specifiers need rewriting: every graphql import resolves through
+# the bare "graphql" package root (see fix-hybrid-module.sh for details).

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lodash.get": "^4.4.2"
   },
   "peerDependencies": {
-    "graphql": "^15.0.0 || ^16.0.0"
+    "graphql": "^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "files": [
     "dist",
@@ -66,7 +66,7 @@
     "@typescript-eslint/parser": "^5.1.0",
     "chai": "^4.3.4",
     "eslint": "^8.0.1",
-    "graphql": "~14.6.0 || ~15.0.0 || ~16.0.0",
+    "graphql": "~14.6.0 || ~15.0.0 || ~16.0.0 || ~17.0.0",
     "mocha": "^11.7.6",
     "prettier": "^2.4.1",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lodash.get": "^4.4.2"
   },
   "peerDependencies": {
-    "graphql": "^15.0.0 || ^16.0.0 || ^17.0.0"
+    "graphql": "^16.6.0 || ^17.0.0"
   },
   "files": [
     "dist",
@@ -66,7 +66,7 @@
     "@typescript-eslint/parser": "^5.1.0",
     "chai": "^4.3.4",
     "eslint": "^8.0.1",
-    "graphql": "~14.6.0 || ~15.0.0 || ~16.0.0 || ~17.0.0",
+    "graphql": "~16.6.0 || ~17.0.0",
     "mocha": "^11.7.6",
     "prettier": "^2.4.1",
     "rimraf": "^3.0.2",

--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -8,9 +8,6 @@ import {
   getArgumentValues,
   getDirectiveValues,
   getVariableValues,
-} from 'graphql/execution/values';
-
-import {
   ValidationContext,
   FragmentDefinitionNode,
   OperationDefinitionNode,
@@ -33,7 +30,6 @@ import {
   GraphQLUnionType,
   GraphQLObjectType,
   GraphQLInterfaceType,
-  Kind,
   getNamedType,
   GraphQLError,
   SchemaMetaFieldDef,
@@ -188,7 +184,7 @@ export default class QueryComplexity {
 
     // Get variable values from variables that are passed from options, merged
     // with default values defined in the operation
-    const { coerced, errors } = getCoercedVariableValues(
+    const { variableValues, errors } = getOperationVariableValues(
       this.context.getSchema(),
       // We have to create a new array here because input argument is not readonly in graphql ~14.6.0
       operation.variableDefinitions ? [...operation.variableDefinitions] : [],
@@ -199,7 +195,7 @@ export default class QueryComplexity {
       errors.forEach((error) => this.context.reportError(error));
       return;
     }
-    this.variableValues = coerced;
+    this.variableValues = variableValues;
 
     switch (operation.operation) {
       case 'query':
@@ -304,7 +300,7 @@ export default class QueryComplexity {
                   const values = getDirectiveValues(
                     this.includeDirectiveDef,
                     childNode,
-                    this.variableValues || {}
+                    getExecutionVariableValues(this.variableValues)
                   );
                   if (typeof values.if === 'boolean') {
                     includeNode = values.if;
@@ -315,7 +311,7 @@ export default class QueryComplexity {
                   const values = getDirectiveValues(
                     this.skipDirectiveDef,
                     childNode,
-                    this.variableValues || {}
+                    getExecutionVariableValues(this.variableValues)
                   );
                   if (typeof values.if === 'boolean') {
                     skipNode = values.if;
@@ -330,7 +326,7 @@ export default class QueryComplexity {
             }
 
             switch (childNode.kind) {
-              case Kind.FIELD: {
+              case 'Field': {
                 let field = null;
 
                 switch (childNode.name.value) {
@@ -360,7 +356,7 @@ export default class QueryComplexity {
                   args = getArgumentValues(
                     field,
                     childNode,
-                    this.variableValues || {}
+                    getExecutionVariableValues(this.variableValues)
                   );
                 } catch (e) {
                   this.context.reportError(e);
@@ -415,7 +411,7 @@ export default class QueryComplexity {
                 }
                 break;
               }
-              case Kind.FRAGMENT_SPREAD: {
+              case 'FragmentSpread': {
                 const fragmentName = childNode.name.value;
                 const fragment = this.context.getFragment(fragmentName);
                 // Unknown fragment, should be caught by other validation rules
@@ -463,7 +459,7 @@ export default class QueryComplexity {
                 }
                 break;
               }
-              case Kind.INLINE_FRAGMENT: {
+              case 'InlineFragment': {
                 let inlineFragmentType: GraphQLNamedType = typeDef;
                 if (childNode.typeCondition && childNode.typeCondition.name) {
                   inlineFragmentType = this.context
@@ -500,8 +496,17 @@ export default class QueryComplexity {
                 break;
               }
               default: {
+                // Unreachable: all selection kinds (Field, FragmentSpread,
+                // InlineFragment) are handled above. The cast keeps this
+                // compatible across graphql versions whose AST `kind` typings
+                // differ (enum vs string literal), which affect how the switch
+                // narrows the node type in this branch.
                 innerComplexities = addComplexities(
-                  this.nodeComplexity(childNode, typeDef, activeFragments),
+                  this.nodeComplexity(
+                    childNode as FieldNode,
+                    typeDef,
+                    activeFragments
+                  ),
                   complexities,
                   possibleTypeNames
                 );
@@ -537,27 +542,43 @@ export default class QueryComplexity {
 
 /**
  * GraphQL v17 changed getVariableValues() to return { variableValues }
- * instead of { coerced }. This helper supports both shapes.
+ * (an object with a `coerced` map) instead of a `{ coerced }` map directly.
+ * This helper normalizes both shapes to the container the running graphql
+ * version expects, without referencing any version-specific graphql types
+ * (which would leak into this package's published type definitions).
  */
-function getCoercedVariableValues(
+function getOperationVariableValues(
   schema: GraphQLSchema,
   variableDefinitions: readonly VariableDefinitionNode[],
   inputs: Record<string, any>
-): { coerced: Record<string, any>; errors?: ReadonlyArray<GraphQLError> } {
-  const result = getVariableValues(
-    schema,
-    variableDefinitions ?? [],
-    inputs
-  ) as {
+): {
+  variableValues: Record<string, any>;
+  errors?: ReadonlyArray<GraphQLError>;
+} {
+  const result = getVariableValues(schema, variableDefinitions, inputs) as {
     coerced?: Record<string, any>;
-    variableValues?: { coerced: Record<string, any> };
+    variableValues?: Record<string, any>;
     errors?: ReadonlyArray<GraphQLError>;
   };
 
   return {
-    coerced: result.variableValues?.coerced ?? result.coerced ?? {},
+    variableValues: result.variableValues ?? result.coerced ?? {},
     errors: result.errors,
   };
+}
+
+/**
+ * Returns the variable values in the form expected by getArgumentValues /
+ * getDirectiveValues. graphql >= 17 receives the `{ coerced, sources }`
+ * container as-is; graphql <= 16 receives the plain coerced map. An empty map
+ * (no variables) is passed as undefined for both.
+ */
+function getExecutionVariableValues(variableValues: Record<string, any>): any {
+  if (!variableValues || Object.keys(variableValues).length === 0) {
+    return undefined;
+  }
+
+  return variableValues;
 }
 
 /**

--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -568,10 +568,9 @@ function getOperationVariableValues(
 }
 
 /**
- * Returns the variable values in the form expected by getArgumentValues /
- * getDirectiveValues. graphql >= 17 receives the `{ coerced, sources }`
- * container as-is; graphql <= 16 receives the plain coerced map. An empty map
- * (no variables) is passed as undefined for both.
+ * Forwards the version-correct variable values (already shaped by
+ * getOperationVariableValues) to getArgumentValues / getDirectiveValues
+ * unchanged, mapping only the empty case to `undefined`.
  */
 function getExecutionVariableValues(variableValues: Record<string, any>): any {
   if (!variableValues || Object.keys(variableValues).length === 0) {

--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -14,6 +14,7 @@ import {
   ValidationContext,
   FragmentDefinitionNode,
   OperationDefinitionNode,
+  VariableDefinitionNode,
   FieldNode,
   FragmentSpreadNode,
   InlineFragmentNode,
@@ -187,7 +188,7 @@ export default class QueryComplexity {
 
     // Get variable values from variables that are passed from options, merged
     // with default values defined in the operation
-    const { coerced, errors } = getVariableValues(
+    const { coerced, errors } = getCoercedVariableValues(
       this.context.getSchema(),
       // We have to create a new array here because input argument is not readonly in graphql ~14.6.0
       operation.variableDefinitions ? [...operation.variableDefinitions] : [],
@@ -532,6 +533,31 @@ export default class QueryComplexity {
       queryComplexityMessage(this.options.maximumComplexity, this.complexity)
     );
   }
+}
+
+/**
+ * GraphQL v17 changed getVariableValues() to return { variableValues }
+ * instead of { coerced }. This helper supports both shapes.
+ */
+function getCoercedVariableValues(
+  schema: GraphQLSchema,
+  variableDefinitions: readonly VariableDefinitionNode[],
+  inputs: Record<string, any>
+): { coerced: Record<string, any>; errors?: ReadonlyArray<GraphQLError> } {
+  const result = getVariableValues(
+    schema,
+    variableDefinitions ?? [],
+    inputs
+  ) as {
+    coerced?: Record<string, any>;
+    variableValues?: { coerced: Record<string, any> };
+    errors?: ReadonlyArray<GraphQLError>;
+  };
+
+  return {
+    coerced: result.variableValues?.coerced ?? result.coerced ?? {},
+    errors: result.errors,
+  };
 }
 
 /**

--- a/src/__tests__/QueryComplexity-test.ts
+++ b/src/__tests__/QueryComplexity-test.ts
@@ -65,6 +65,32 @@ describe('QueryComplexity analysis', () => {
     expect(complexity).to.equal(0);
   });
 
+  it('should respect @include(if: $show) with explicit variable value', () => {
+    const ast = parse(`
+      query Foo ($show: Boolean!) {
+        variableScalar(count: 10) @include(if: $show)
+      }
+    `);
+
+    expect(
+      getComplexity({
+        estimators: [simpleEstimator({ defaultComplexity: 1 })],
+        schema,
+        query: ast,
+        variables: { show: true },
+      })
+    ).to.equal(1);
+
+    expect(
+      getComplexity({
+        estimators: [simpleEstimator({ defaultComplexity: 1 })],
+        schema,
+        query: ast,
+        variables: { show: false },
+      })
+    ).to.equal(0);
+  });
+
   it('should respect @include(if: false)', () => {
     const ast = parse(`
       query {

--- a/src/__tests__/QueryComplexity-test.ts
+++ b/src/__tests__/QueryComplexity-test.ts
@@ -494,8 +494,8 @@ describe('QueryComplexity analysis', () => {
     });
     visit(ast, visitWithTypeInfo(typeInfo, visitor));
     expect(context.getErrors().length).to.equal(1);
-    expect(context.getErrors()[0].message).to.equal(
-      'Argument "count" of required type "Int!" was not provided.'
+    expect(context.getErrors()[0].message).to.match(
+      /^Argument "(?:count|Query\.requiredArgs\(count:\))" of required type "Int!" was not provided\.$/
     );
   });
 

--- a/src/estimators/fieldExtensions/__tests__/fieldExtensionsEstimator-test.ts
+++ b/src/estimators/fieldExtensions/__tests__/fieldExtensionsEstimator-test.ts
@@ -303,8 +303,8 @@ describe('fieldExtensions estimator', () => {
     });
     visit(ast, visitWithTypeInfo(typeInfo, visitor));
     expect(context.getErrors().length).to.equal(1);
-    expect(context.getErrors()[0].message).to.equal(
-      'Argument "count" of required type "Int!" was not provided.'
+    expect(context.getErrors()[0].message).to.match(
+      /^Argument "(?:count|Query\.requiredArgs\(count:\))" of required type "Int!" was not provided\.$/
     );
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "paths": {
       "*": ["node_modules/*", "src/types/*"]
     },
-    "lib": ["esnext", "esnext.asynciterable"]
+    "lib": ["esnext", "esnext.asynciterable", "DOM"]
   },
   "include": ["src/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -721,10 +721,10 @@ globby@^11.0.4:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-"graphql@~14.6.0 || ~15.0.0 || ~16.0.0 || ~17.0.0":
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.0.1.tgz#93a13cd4e0e38ca8d0832e79614c8578bfd34f10"
-  integrity sha512-oPvCuu6dlLdiz8gZupJ47o1clgb72r1u8NDBcQYjcV6G/iEdmE11B1bBlkhXRvV0LisP/SXRFP7tT6AgaTjpzg==
+"graphql@~16.6.0 || ~17.0.0":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-17.0.2.tgz#05ff6f18e0801e8d040d46957eba712c1459d5d7"
+  integrity sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==
 
 has-flag@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -721,7 +721,7 @@ globby@^11.0.4:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-"graphql@~14.6.0 || ~15.0.0 || ~16.0.0":
+"graphql@~14.6.0 || ~15.0.0 || ~16.0.0 || ~17.0.0":
   version "16.0.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.0.1.tgz#93a13cd4e0e38ca8d0832e79614c8578bfd34f10"
   integrity sha512-oPvCuu6dlLdiz8gZupJ47o1clgb72r1u8NDBcQYjcV6G/iEdmE11B1bBlkhXRvV0LisP/SXRFP7tT6AgaTjpzg==


### PR DESCRIPTION
## Summary

Adds GraphQL 17 support and simplifies hybrid CJS/ESM packaging by importing all graphql utilities from the package root.

Addresses #103 

- **GraphQL 17 compatibility**: Handle `getVariableValues()` returning `{ variableValues }` instead of `{ coerced }`, use string-literal AST `kind` checks (GraphQL 17 makes `Kind` type-only), and relax error-message assertions for GraphQL 17's more verbose argument errors.
- **Single-instance safety**: Drop the deep `graphql/execution/values` import and all `sed`-based import rewriting in the hybrid-module scripts. Every graphql import now goes through the bare `graphql` specifier, which avoids mixing ESM/CJS copies of graphql in the same realm.
- **Version support changes**:
  - `peerDependencies.graphql`: `^16.6.0 || ^17.0.0` (drops 15.x and 16.0–16.5; `getVariableValues`/`getArgumentValues` became root exports in 16.6)
  - CI matrix: graphql `~16.6`, `~16`, `~17.0`; Node 20 removed from CI
- **Build**: Add `"DOM"` to `tsconfig.json` `lib` so GraphQL 17's type definitions compile under TypeScript 4.4 (for `AbortSignal`/`AbortController` references).

## Breaking changes

- Minimum supported `graphql` version is now **16.6.0** (was 15.0.0).
- Node 20 is no longer tested in CI.

## Test plan

- [x] `yarn test` passes on graphql 16.6.0, 16.14.2, and 17.0.2 (CJS + ESM)
- [x] New test: `@include(if: $show)` with explicit variable values (covers variable → directive coercion across graphql versions)
- [x] Built `dist/` artifacts contain only bare `graphql` imports (no deep imports, no `.mjs`/`.js` rewrites)
- [x] Isolated consumer smoke test against published `dist/` on graphql 17 (no realm crash)